### PR TITLE
Fix array assignment bug

### DIFF
--- a/src/GoogleBooksApi.php
+++ b/src/GoogleBooksApi.php
@@ -235,6 +235,7 @@ class GoogleBooksApi implements \Iterator, \Countable
         if ($value === false) {
             $this->paramaters[$paramater] = $name;
         } else {
+            $this->paramaters[$paramater] = [];
             $this->paramaters[$paramater][$name] = $value;
         }
         return $this;


### PR DESCRIPTION
Hi!

I found that this call:

```
...->search($term)->limit(10)->all();
```
is returning this error


```
(1/1) ContextErrorExceptionWarning: Illegal string offset ''
--
in GoogleBooksApi.php (line 240)
at GoogleBooksApi->add('q', '', 'harry potter')in GoogleBooksApi.php (line 333)
at GoogleBooksApi->query('', 'harry potter')in GoogleBooksApi.php (line 347)
at GoogleBooksApi->search('harry potter')in BooksRepository.php (line 23)
at BooksRepository->search('harry potter', 'books')in ItemRepository.php (line 40)
at ItemRepository->search('books', 'harry potter')in GetItemsQuery.php (line 41)
at GetItemsQuery->handle('books', 'harry potter')in ItemController.php (line 19)
at ItemController->getAll('books')in Item.php (line 30)
at Item->Rekomendo\Infrastructure\Route\Api\{closure}('books')
at call_user_func_array(object(Closure), array('books'))in HttpKernel.php (line 144)
at HttpKernel->handleRaw(object(Request), 1)in HttpKernel.php (line 64)
at HttpKernel->handle(object(Request), 1, true)in Application.php (line 586)
at Application->handle(object(Request))in Application.php (line 563)
at Application->run()in app.php (line 18)
```
I've tried to fix the problem within this PR.

Regards!
